### PR TITLE
ci(dependabot): update interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,12 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
 
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       all:
         patterns: ["*"]
@@ -17,4 +17,4 @@ updates:
   - package-ecosystem: gomod
     directory: .sage
     schedule:
-      interval: weekly
+      interval: monthly


### PR DESCRIPTION
## Update dependabot interval
### Why?
- We are getting a lot of these dependabot PRs, and often!
### What?
- Update schedule to monthly interval.
### Notes
- This PR was generated with [multipr](https://github.com/fredrikaverpil/multipr)
